### PR TITLE
Fix leak when fail convert

### DIFF
--- a/src/libeot.c
+++ b/src/libeot.c
@@ -59,6 +59,7 @@ enum EOTError EOT2ttf_file(const uint8_t *font, unsigned fontSize,
       metadataOut->flags & TTEMBED_TTCOMPRESSED,
       metadataOut->flags & TTEMBED_XORENCRYPTDATA, out);
   if (writeResult != EOT_SUCCESS) {
+    EOTfreeMetadata(metadataOut);
     return writeResult;
   }
   return EOT_SUCCESS;
@@ -82,6 +83,7 @@ enum EOTError EOT2ttf_buffer(const uint8_t *font, unsigned fontSize,
   if (result >= EOT_WARN) {
     EOTprintError(result, stderr);
   } else if (writeResult != EOT_SUCCESS) {
+    EOTfreeMetadata(metadataOut);
     return writeResult;
   }
   return EOT_SUCCESS;

--- a/src/lzcomp/lzcomp.c
+++ b/src/lzcomp/lzcomp.c
@@ -812,6 +812,11 @@ static unsigned char *Decode(register LZCOMP *t, long *size)
         if (distance >= max_2Byte_Dist)
           length++;
         start = pos - distance - length + 1;
+        // out-of-bound
+        if (start < (-1)*preLoadSize || start + length >= t->out_len) {
+            MTX_mem_free( t->mem, dataOut);
+            return NULL;
+        }
         for (j = 0; j < length; j++) {
           value = ptr1[start + j];
           ptr1[pos++] = value;
@@ -1109,7 +1114,7 @@ unsigned char *MTX_LZCOMP_UnPackMemory(register LZCOMP *t, void *dataIn,
   MTX_RUNLENGTHCOMP_Destroy(t->rlComp);
   t->rlComp = NULL;
 
-  assert(t->usingRunLength || *sizeOut < maxOutSize);
+  if (dataOut) assert(t->usingRunLength || *sizeOut < maxOutSize);
 
 #ifdef VERBOSE
   /*cout << "Wrote " << *sizeOut << " Bytes to file <" << outName << ">" <<


### PR DESCRIPTION
If EOTfillMetadata() success but convert is failed => need to free "metadataOut" too.

==939885== 58 bytes in 1 blocks are definitely lost in loss record 4 of 5
==939885==    at 0x483C815: malloc (vg_replace_malloc.c:446)
==939885==    by 0x485621E: EOTgetString (EOT.c:51)
==939885==    by 0x4856AA9: EOTfillMetadataSpecifyingVersion (EOT.c:188)
==939885==    by 0x4857163: EOTfillMetadata (EOT.c:272)
==939885==    by 0x4855EBA: EOT2ttf_file (libeot.c:50)
==939885==    by 0x109496: main (eot2ttf.c:55)