### PR TITLE
Don't return EOT_SUCCESS when writeFontBuffer fails

### DIFF
--- a/src/libeot.c
+++ b/src/libeot.c
@@ -79,8 +79,8 @@ enum EOTError EOT2ttf_buffer(const uint8_t *font, unsigned fontSize,
       font + metadataOut->fontDataOffset, metadataOut->fontDataSize,
       metadataOut->flags & TTEMBED_TTCOMPRESSED,
       metadataOut->flags & TTEMBED_XORENCRYPTDATA, fontOut, fontSizeOut);
-  if (result >= EOT_WARN) {
-    EOTprintError(result, stderr);
+  if (writeResult >= EOT_WARN) {
+    EOTprintError(writeResult, stderr);
   } else if (writeResult != EOT_SUCCESS) {
     return writeResult;
   }


### PR DESCRIPTION
The second result check in EOT2ttf_buffer tested the metadata result instead of the write result.