### PR TITLE
fix: dumpContainer() does not write checksum

### DIFF
--- a/src/ctf/SFNTContainer.c
+++ b/src/ctf/SFNTContainer.c
@@ -193,10 +193,9 @@ enum EOTError dumpContainer(struct SFNTContainer *ctr, uint8_t **outBuf,
   /* this mystical number 0xB1B0AFBA is defined by the TTF standard, dunno why
    * they picked this value. */
   unsigned finalChecksum = 0xB1B0AFBA - chk;
-  struct Stream sChkOut = constructStream(head->buf, head->bufSize);
-  sResult = seekAbsolute(&sChkOut, 8);
+  sResult = seekAbsolute(&s, head->offset + 8);
   CHK_CN(sResult, EOT_LOGIC_ERROR);
-  sResult = BEWriteU32(&sChkOut, finalChecksum);
+  sResult = BEWriteU32(&s, finalChecksum);
   CHK_CN(sResult, EOT_LOGIC_ERROR);
   returnedStatus = EOT_SUCCESS;
   *outBuf = s.buf;

--- a/src/util/stream.c
+++ b/src/util/stream.c
@@ -322,11 +322,14 @@ enum StreamResult BEcheckSum32(struct Stream *s, uint32_t *out,
     return EOT_NOT_ENOUGH_DATA;
   }
   struct Stream slice = constructStream(s->buf + beginPos, endPos - beginPos);
-  enum StreamResult sResult = EOT_STREAM_OK;
   *out = 0;
-  while (sResult == EOT_STREAM_OK) {
+  enum StreamResult sResult = EOT_STREAM_OK;
+  while (true) {
     uint32_t chunk;
     sResult = BEReadRestAsU32(&slice, &chunk);
+    if (sResult != EOT_STREAM_OK) {
+      break;
+    }
     *out += chunk;
   }
   if (sResult == EOT_NOT_ENOUGH_DATA) {


### PR DESCRIPTION
dumpContainer() writes the checksum to an old buffer, effectively a noop. It doesn't look intentional(?)